### PR TITLE
Log script load errors properly

### DIFF
--- a/src/javascripts/scriptLoader/scriptLoader.js
+++ b/src/javascripts/scriptLoader/scriptLoader.js
@@ -100,9 +100,9 @@ function scriptLoader (options, callback) {
 		}
 	};
 
-	script.onerror = function () {
+	script.onerror = function (err) {
 		destroy();
-		error(new Error("Error loading script."));
+		error(err);
 	};
 
 	head.insertBefore( script, head.firstChild );


### PR DESCRIPTION
@roland-vachter 

At present the error message isn't very informative when it comes to debugging why the script failed https://app.getsentry.com/nextftcom/frontend/issues/127153836/events/4184694118/. I suggest we change to using the native error message for a while, try to isolate some common reasons for failure, handle them properly and then only log any errors which don't fit any handled patterns
