### PR TITLE
Revert "Log script load errors properly"

### DIFF
--- a/src/javascripts/scriptLoader/scriptLoader.js
+++ b/src/javascripts/scriptLoader/scriptLoader.js
@@ -100,9 +100,9 @@ function scriptLoader (options, callback) {
 		}
 	};
 
-	script.onerror = function (err) {
+	script.onerror = function () {
 		destroy();
-		error(err);
+		error(new Error("Error loading script."));
 	};
 
 	head.insertBefore( script, head.firstChild );


### PR DESCRIPTION
Reverts Financial-Times/o-comment-utilities#1

After reading up more on script error handling, I don't think this will work, but I still don't think  these errors should end up getting passed to oErrors (I'm not sure if that's done in o-comments or in next)
